### PR TITLE
show concerned object in updateTokenTTLMetric() errors

### DIFF
--- a/vaulthealthz.go
+++ b/vaulthealthz.go
@@ -157,11 +157,11 @@ func (s *Service) updateTokenTTLMetric() error {
 	}
 	e, ok := key.(string)
 	if !ok {
-		return microerror.Maskf(executionFailedError, "'%#v' must be string in order to collect metrics for the Vault token expiration", e)
+		return microerror.Maskf(executionFailedError, "'%#v' must be string in order to collect metrics for the Vault token expiration", key)
 	}
 	split := strings.Split(e, ".")
 	if len(split) == 0 {
-		return microerror.Maskf(executionFailedError, "'%#v' must have at least one item in order to collect metrics for the Vault token expiration", split)
+		return microerror.Maskf(executionFailedError, "'%#v' must have at least one item in order to collect metrics for the Vault token expiration", e)
 	}
 	expireTime := split[0]
 


### PR DESCRIPTION
Came accros the following error
`'""' must be string in order to collect metrics for the Vault token expiration: execution failed`

Where `""` is the result of a failed string assertion due to a nil value.
It should instead show the incriminated `<nil>` object.

I would expect to see the following error instead
`'<nil>' must be string in order to collect metrics for the Vault token expiration: execution failed`
