### PR TITLE
handle case where vault token has no expiration

### DIFF
--- a/vaulthealthz.go
+++ b/vaulthealthz.go
@@ -157,7 +157,7 @@ func (s *Service) updateTokenTTLMetric() error {
 	}
 
 	if key == nil {
-		s.logger.Log("Vault token does not expire, skipping metric update")
+		s.logger.r.logger.LogCtx(ctx, "level", "info", "message", "Vault token does not expire, skipping metric update")
 		return nil
 	}
 

--- a/vaulthealthz.go
+++ b/vaulthealthz.go
@@ -3,7 +3,6 @@ package vaulthealthz
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -158,7 +157,7 @@ func (s *Service) updateTokenTTLMetric() error {
 	}
 
 	if key == nil {
-		log.Print("Vault token does not expire, skipping metric update")
+		s.logger.Log("Vault token does not expire, skipping metric update")
 		return nil
 	}
 

--- a/vaulthealthz.go
+++ b/vaulthealthz.go
@@ -157,7 +157,7 @@ func (s *Service) updateTokenTTLMetric() error {
 	}
 
 	if key == nil {
-		s.logger.r.logger.LogCtx(ctx, "level", "info", "message", "Vault token does not expire, skipping metric update")
+		s.logger.r.logger.Log("level", "info", "message", "Vault token does not expire, skipping metric update")
 		return nil
 	}
 

--- a/vaulthealthz.go
+++ b/vaulthealthz.go
@@ -155,6 +155,13 @@ func (s *Service) updateTokenTTLMetric() error {
 	if !ok {
 		return microerror.Maskf(executionFailedError, "value of '%s' must exist in order to collect metrics for the Vault token expiration", ExpireTimeKey)
 	}
+
+	if key == nil {
+		// Vault token does not expire.
+		tokenExpireTimeGauge.Set(-1)
+		return nil
+	}
+
 	e, ok := key.(string)
 	if !ok {
 		return microerror.Maskf(executionFailedError, "'%#v' must be string in order to collect metrics for the Vault token expiration", key)

--- a/vaulthealthz.go
+++ b/vaulthealthz.go
@@ -3,6 +3,7 @@ package vaulthealthz
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -157,8 +158,7 @@ func (s *Service) updateTokenTTLMetric() error {
 	}
 
 	if key == nil {
-		// Vault token does not expire.
-		tokenExpireTimeGauge.Set(-1)
+		log.Print("Vault token does not expire, skipping metric update")
 		return nil
 	}
 

--- a/vaulthealthz.go
+++ b/vaulthealthz.go
@@ -157,7 +157,7 @@ func (s *Service) updateTokenTTLMetric() error {
 	}
 
 	if key == nil {
-		s.logger.r.logger.Log("level", "info", "message", "Vault token does not expire, skipping metric update")
+		s.logger.Log("level", "info", "message", "Vault token does not expire, skipping metric update")
 		return nil
 	}
 


### PR DESCRIPTION
Related to https://github.com/giantswarm/vaultlab/pull/1 and https://github.com/giantswarm/vaulthealthz/pull/6

When running `vault` in dev mode, the root token has no expiration set.
```
$ docker run --cap-add=IPC_LOCK -d -p 8200:8200 -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' vault:0.9.3 server -dev
$ curl localhost:8200/v1/auth/token/lookup-self -H"X-Vault-Token:myroot"
{
    "auth": null,
    "data": {
        "accessor": "d1aba86e-bbd8-bf46-34ea-e884bd7812fe",
        "creation_time": 1523529605,
        "creation_ttl": 0,
        "display_name": "token",
        "entity_id": "",
        "expire_time": null,
        "explicit_max_ttl": 0,
        "id": "myroot",
        "issue_time": "2018-04-12T10:40:05.0044932Z",
        "meta": null,
        "num_uses": 0,
        "orphan": true,
        "path": "auth/token/create",
        "policies": [
            "root"
        ],
        "renewable": false,
        "ttl": 0
    },
    "lease_duration": 0,
    "lease_id": "",
    "renewable": false,
    "request_id": "7d67c722-5062-38f8-ecd0-811e880e2051",
    "warnings": null,
    "wrap_info": null
}
```

This result in `updateTokenTTLMetric()` failing with the following error, because we expect a string to be present under the `expire_time`
`'nil' must be string in order to collect metrics for the Vault token expiration: execution failed`


I propose here a fix, which to set the prometheus `token_expire_time` to `-1` when token has no expire time.

